### PR TITLE
Fix hardhat tests (overloaded functions)

### DIFF
--- a/test/PoolManager.gas.spec.ts
+++ b/test/PoolManager.gas.spec.ts
@@ -80,7 +80,7 @@ describe('PoolManager gas tests', () => {
       }
 
       const swapExact0For1: SwapFunction = (amount, to, sqrtPriceLimitX96) => {
-        return swapTest.swap(
+        return swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           poolKey,
           {
             zeroForOne: true,
@@ -94,7 +94,7 @@ describe('PoolManager gas tests', () => {
         )
       }
       const swapToHigherPrice: SwapToPriceFunction = (sqrtPriceX96, to) => {
-        return swapTest.swap(
+        return swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           poolKey,
           {
             zeroForOne: false,
@@ -122,7 +122,7 @@ describe('PoolManager gas tests', () => {
         )
       }
       const modifyPosition: ModifyPositionFunction = (tickLower, tickUpper, liquidityDelta) => {
-        return modifyPositionTest.modifyPosition(poolKey, {
+        return modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](poolKey, {
           tickLower,
           tickUpper,
           liquidityDelta,
@@ -362,7 +362,7 @@ describe('PoolManager gas tests', () => {
       }
 
       const swapExact0For1: SwapFunction = (amount, to, sqrtPriceLimitX96) => {
-        return swapTest.swap(
+        return swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           poolKey,
           {
             zeroForOne: true,
@@ -379,7 +379,7 @@ describe('PoolManager gas tests', () => {
         )
       }
       const swapToHigherPrice: SwapToPriceFunction = (sqrtPriceX96, to) => {
-        return swapTest.swap(
+        return swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           poolKey,
           {
             zeroForOne: false,
@@ -410,7 +410,7 @@ describe('PoolManager gas tests', () => {
         )
       }
       const modifyPosition: ModifyPositionFunction = (tickLower, tickUpper, liquidityDelta) => {
-        return modifyPositionTest.modifyPosition(
+        return modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](
           poolKey,
           {
             tickLower,

--- a/test/PoolManager.spec.ts
+++ b/test/PoolManager.spec.ts
@@ -138,7 +138,7 @@ describe('PoolManager', () => {
       }
       await invalidToken.approve(modifyPositionTest.address, constants.MaxUint256)
       await manager.initialize(key, encodeSqrtPriceX96(1, 1), '0x00')
-      await modifyPositionTest.modifyPosition(key, {
+      await modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](key, {
         tickLower: -60,
         tickUpper: 60,
         liquidityDelta: 100,
@@ -162,7 +162,7 @@ describe('PoolManager', () => {
         tickSpacing: 10,
       }
       await manager.initialize(key, encodeSqrtPriceX96(1, 1), '0x00')
-      await modifyPositionTest.modifyPosition(key, {
+      await modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](key, {
         tickLower: -60,
         tickUpper: 60,
         liquidityDelta: 100,
@@ -183,7 +183,7 @@ describe('PoolManager', () => {
         tickSpacing: 10,
       }
       await manager.initialize(key, encodeSqrtPriceX96(1, 1), '0x00')
-      await modifyPositionTest.modifyPosition(
+      await modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](
         key,
         {
           tickLower: -60,
@@ -261,7 +261,7 @@ describe('PoolManager', () => {
         expect(protocolFees).to.eq(BigNumber.from(poolProtocolFee).shl(12))
 
         // add liquidity around the initial price
-        await modifyPositionTest.modifyPosition(poolKey, {
+        await modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](poolKey, {
           tickLower: -120,
           tickUpper: 120,
           liquidityDelta: expandTo18Decimals(10),
@@ -269,7 +269,7 @@ describe('PoolManager', () => {
       })
 
       it('allows the owner to collect accumulated fees', async () => {
-        await swapTest.swap(
+        await swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           {
             currency0: tokens.currency0.address,
             currency1: tokens.currency1.address,
@@ -311,7 +311,7 @@ describe('PoolManager', () => {
       })
 
       it('returns all fees if 0 is provided', async () => {
-        await swapTest.swap(
+        await swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           {
             currency0: tokens.currency0.address,
             currency1: tokens.currency1.address,
@@ -377,7 +377,7 @@ describe('PoolManager', () => {
         expect(protocolFees).to.eq(BigNumber.from(poolProtocolFee).shl(12))
 
         // add liquidity around the initial price
-        await modifyPositionTest.modifyPosition(
+        await modifyPositionTest["modifyPosition((address,address,uint24,int24,address),(int24,int24,int256))"](
           poolKey,
           {
             tickLower: -120,
@@ -391,7 +391,7 @@ describe('PoolManager', () => {
       })
 
       it('allows the owner to collect accumulated fees', async () => {
-        await swapTest.swap(
+        await swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           {
             currency0: ADDRESS_ZERO,
             currency1: tokens.currency1.address,
@@ -436,7 +436,7 @@ describe('PoolManager', () => {
       })
 
       it('returns all fees if 0 is provided', async () => {
-        await swapTest.swap(
+        await swapTest["swap((address,address,uint24,int24,address),(bool,int256,uint160),(bool,bool))"](
           {
             currency0: ADDRESS_ZERO,
             currency1: tokens.currency1.address,


### PR DESCRIPTION
Overloaded solidity functions are not inferable by hardhat/ethers. You need to specify the function signature in order to call overloaded functions.

This branch will become unnecessary if we remove the overloaded functions (#1)

---

Also, the gas snapshot tests are failing. I have no idea how to update the expected gas usage